### PR TITLE
Exposing resource type for operation

### DIFF
--- a/src/type/definition/ApiBuilderOperation.ts
+++ b/src/type/definition/ApiBuilderOperation.ts
@@ -35,7 +35,7 @@ export interface ApiBuilderOperationConfig {
 
 export class ApiBuilderOperation {
   private config: ApiBuilderOperationConfig;
-  private resource: ApiBuilderResource;
+  public resource: ApiBuilderResource;
   private service: ApiBuilderService;
 
   constructor(


### PR DESCRIPTION
Specifically used in OpenApi spec generator to add tags to [OperationObjects](https://swagger.io/specification/#operationObject) for more logical grouping by _resource_ (in ApiBuilder terms). 