### PR TITLE
Fix type for attribute values

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -26,6 +26,14 @@ type StrictUnionHelper<T, A> = T extends unknown
 
 type StrictUnion<T> = Compute<StrictUnionHelper<T, T>>;
 
+type JSONValue =
+ | string
+ | number
+ | boolean
+ | null
+ | JSONValue[]
+ | { [key: string]: JSONValue };
+
 export interface ApiBuilderAnnotationConfig {
   readonly name: string;
   readonly description?: string;
@@ -69,7 +77,7 @@ export class ApiBuilderArray {
  */
 export interface ApiBuilderAttributeConfig {
   readonly name: string;
-  readonly value: Record<string, string>;
+  readonly value: JSONValue;
   readonly description?: string;
   readonly deprecation?: ApiBuilderDeprecationConfig;
 }


### PR DESCRIPTION
Looks like we missed that attribute values are JSON values.
https://app.apibuilder.io/apicollective/apibuilder-spec/latest#model-attribute